### PR TITLE
GPII-362: Updates the Ant build target to the Android 18 SDK.

### DIFF
--- a/platform/app/project.properties
+++ b/platform/app/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-18


### PR DESCRIPTION
@javihernandez can you take a look at this pull request? I'm not sure this is the appropriate approach, since project.properties is an autogenerated file. Running the latest Android Development Tools, however, I couldn't build the realtime framework without this fix.

Is this the correct way to do this, or should we be somehow modifying our prebuild.sh script or something else?
