### PR TITLE
Added minSdkVersion to manifest file, fixes weird layout problem

### DIFF
--- a/platform/app/AndroidManifest.xml
+++ b/platform/app/AndroidManifest.xml
@@ -20,6 +20,7 @@
 <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
 <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
+<uses-sdk android:minSdkVersion="4"/>
 
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
         <activity android:name="GpiiActivity"


### PR DESCRIPTION
Using a Samsung Note 10.1 2014 edition (tablet) in landscape mode, this happens: 
![screenshot_2013-11-14-09-59-06](https://f.cloud.github.com/assets/817123/1540854/ad7a3204-4d29-11e3-9044-9e046ff0ff35.png)

After adding minSdkVersion:

![screenshot_2013-11-14-09-59-43](https://f.cloud.github.com/assets/817123/1540859/bba6f6c8-4d29-11e3-9148-0a01df28f7ce.png)
Keep in mind that it's a 10.1" display, so that logo was HUGE and you could not scroll down or otherwise access the buttons below.

SDK version 4 is the lowest version that still works properly. Using later versions (15+ or so) gives the app a different look (blue-ish buttons and added Action Bar), but no difference otherwise.
