### PR TITLE
GPII-458: Remove .tar and .tar.gz files separately

### DIFF
--- a/android-gpii.sh
+++ b/android-gpii.sh
@@ -69,7 +69,7 @@ function gpii-install-gpii {
     cp -R $universal ./gpii/node_modules/
     cp $android_gpii_dir/gpii.js ./gpii/android/
     tar czf gpii-android.tar.gz gpii
-    adb shell 'cd /sdcard; rm gpii-android.tar.gz gpii-android.tar'
+    adb shell 'cd /sdcard; rm gpii-android.tar.gz; rm gpii-android.tar'
     adb push gpii-android.tar.gz /sdcard/gpii-android.tar.gz
     cd $android_gpii_dir
     adb shell 'cd /sdcard; gunzip gpii-android.tar.gz; tar xvf gpii-android.tar'


### PR DESCRIPTION
The rm command fails when the .tar.gz file doesn't exist, as a
consequence of this, the .tar file is not being removed. But this is not
the problem, the real one is that the gunzip command doesn't works if
the .tar file exists.

Look at this:

<pre>
$ ls -l
-rw-rw-r-- root     sdcard_rw        0 2013-12-05 10:00 jj
-rw-rw-r-- root     sdcard_rw     1536 2013-12-05 10:00 jj.tar
-rw-rw-r-- root     sdcard_rw       91 2013-12-05 10:02 jj.tar.gz
$ rm jj.tar.gz
$ ls
jj
jj.tar
$ ls -l
-rw-rw-r-- root     sdcard_rw        0 2013-12-05 10:00 jj
-rw-rw-r-- root     sdcard_rw     1536 2013-12-05 10:00 jj.tar
$ rm jj.tar.gz jj.tar
rm failed for jj.tar.gz, No such file or directory
$ ls -l
-rw-rw-r-- root     sdcard_rw        0 2013-12-05 10:00 jj
-rw-rw-r-- root     sdcard_rw     1536 2013-12-05 10:00 jj.tar
$ gzip -c jj.tar > jj.tar.gz
$ ls -l
-rw-rw-r-- root     sdcard_rw        0 2013-12-05 10:00 jj
-rw-rw-r-- root     sdcard_rw     1536 2013-12-05 10:00 jj.tar
-rw-rw-r-- root     sdcard_rw       91 2013-12-05 10:04 jj.tar.gz
$ gunzip jj.tar.gz
gunzip: can't open 'jj.tar': File exists
</pre>


Cheers,
Javi
