### PR TITLE
GPII-490: Handling the region code when setting the language

### DIFF
--- a/platform/persistentconfig/src/net/gpii/AndroidPersistentConfigurationImpl.java
+++ b/platform/persistentconfig/src/net/gpii/AndroidPersistentConfigurationImpl.java
@@ -78,8 +78,15 @@ public class AndroidPersistentConfigurationImpl extends AndroidPersistentConfigu
         if (setting.equals("fontScale")) {
             mConfig.fontScale = Float.parseFloat(value);
         } else if (setting.equals("locale")) {
-            Locale locale = new Locale(value);
-            mConfig.locale = locale;
+            if (value.contains("_")) {
+                String language [] = value.split("_");
+                Locale locale = new Locale(language[0],
+                                           language[1]);
+                mConfig.locale = locale;
+            } else {
+                Locale locale = new Locale(value);
+                mConfig.locale = locale;
+            }
         } else {
             value = null;
         }


### PR DESCRIPTION
When the region code is being specified we have to create the locale in a different way.
