### PR TITLE
fixed jtar version anode and dependencies webinos

### DIFF
--- a/platform/prebuild.sh
+++ b/platform/prebuild.sh
@@ -24,7 +24,7 @@ else
     mkdir app/libs
 fi
 
-cp anode/app/contrib/jtar-1.0.4.jar app/libs/
+cp anode/app/contrib/jtar-2.2.jar app/libs/
 
 # Create Assets directory if it doesn't exist yet
 if [ -d 'app/assets' ]; then
@@ -34,6 +34,6 @@ else
 fi
 
 # Fetch node binaries from webinos
-curl -o app/assets/bridge.node https://raw.github.com/webinos/Webinos-Platform/master/webinos/platform/android/app/assets/bridge.node
-curl -o app/assets/libjninode.so https://raw.github.com/webinos/Webinos-Platform/master/webinos/platform/android/app/assets/libjninode.so
+curl -o app/assets/bridge.node https://github.com/webinos/Webinos-Platform/tree/master/webinos/platform/android/app/assets/bridge.node
+curl -o app/assets/libjninode.so https://github.com/webinos/Webinos-Platform/tree/master/webinos/platform/android/app/assets/libjninode.so
 


### PR DESCRIPTION
I had to make some changes to the prebuild.sh script to fetch the right files.
Anode comes with a different jtar version now.
